### PR TITLE
Fix reasoning filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ import {
 // Set up the router
 const router = new AutoPromptRouter({
   OPEN_ROUTER_API_KEY: 'your-api-key', // Get one from openrouter.ai
-  enableLogging: true, // See what's happening under the hood
 });
 
 await router.initialize();
@@ -182,7 +181,6 @@ import {
 const config: RouterConfig = {
   OPEN_ROUTER_API_KEY: 'your-key', // Required
   selectorModel: 'anthropic/claude-3-sonnet', // Optional: which model makes the selection
-  enableLogging: true, // Optional: see detailed logs
 };
 ```
 
@@ -206,6 +204,15 @@ npm run dev
 npm run lint
 npm run typecheck
 npm run format
+```
+
+## Environment Variables
+
+Create a `.env` file and add the following:
+
+```text
+OPEN_ROUTER_API_KEY=your-key
+NODE_ENV=development
 ```
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-llm-selector",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Auto Prompt Router To LLM",
   "type": "module",
   "main": "dist/index.js",

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,7 +17,6 @@ export class AutoPromptRouter {
   constructor(config: RouterConfig) {
     this.config = {
       selectorModel: 'openai/gpt-oss-20b:free',
-      enableLogging: false,
       ...config,
     };
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -70,14 +70,21 @@ export class AutoPromptRouter {
         `Retrieved ${allProfiles.length} model profiles from cache`
       );
 
-      // Step 2: Filter by reasoning requirement ONLY (if needed)
+      // Step 2: Filter by reasoning requirement
       let availableProfiles = allProfiles;
-      if (properties.reasoning) {
+      if (properties.reasoning === true) {
         availableProfiles = allProfiles.filter(
           profile => profile.characteristics.isReasoning
         );
         this.logger.debug(
           `Filtered to ${availableProfiles.length} reasoning-capable models`
+        );
+      } else if (properties.reasoning === false) {
+        availableProfiles = allProfiles.filter(
+          profile => !profile.characteristics.isReasoning
+        );
+        this.logger.debug(
+          `Filtered to ${availableProfiles.length} non-reasoning models`
         );
       }
 
@@ -179,7 +186,7 @@ PROMPT ANALYSIS:
 
 USER REQUIREMENTS:
 - Accuracy Priority: ${properties.accuracy}/1 (1 = highest accuracy needed)
-- Cost Sensitivity: ${properties.cost}/1 (0 = very cost-sensitive, 1 = cost no object)
+- Cost Sensitivity: ${properties.cost}/1 (1 = very cost-sensitive, 0 = cost no object)
 - Speed Priority: ${properties.speed}/1 (1 = fastest response needed)
 - Context Length: ${properties.tokenLimit} tokens minimum
 - Reasoning Required: ${properties.reasoning}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,6 @@ export interface RouterConfig {
   OPEN_ROUTER_API_KEY: string;
   // preferredProvider?: string  // e.g., "openai", "anthropic", "meta-llama"
   selectorModel?: string; // LLM model to use for selection decisions
-  enableLogging?: boolean;
 }
 
 export interface ModelSelection {


### PR DESCRIPTION
This PR updates auto-llm-selector to v2.0.4 with key improvements:

Config & Logging → Removed enableLogging from RouterConfig and related code for simpler configuration.

Model Filtering → Refined reasoning-based filtering for more accurate model selection.

Prompt Analysis → Fixed cost sensitivity logic (1 = very cost-sensitive, 0 = cost no object).

Docs & Setup → Added .env setup instructions and updated README.md.

Version bumped to 2.0.4.