### PR TITLE
FIX/ analytics and Cache env issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-llm-selector",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-llm-selector",
-      "version": "2.0.3",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@tensorflow-models/universal-sentence-encoder": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-llm-selector",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Auto Prompt Router To LLM",
   "type": "module",
   "main": "dist/index.js",

--- a/src/analytics/queue.ts
+++ b/src/analytics/queue.ts
@@ -2,11 +2,12 @@
 import type { AnalyticsEvent, AnalyticsConfig } from '../types.js';
 import { Logger } from '../utils/logger.js';
 import { AnalyticsUtils } from './utils.js';
-import { env } from '../config/env.js';
 
 const logger = new Logger('AnalyticsQueue');
 
-const SUPABASE_ANALYTICS_ENDPOINT = env.SUPABASE_ANALYTICS_ENDPOINT;
+// Hardcoded analytics endpoint - all library users send data here for ML training
+const SUPABASE_ANALYTICS_ENDPOINT =
+  'https://ucgblchamfvkillrznhk.supabase.co/functions/v1/analytics';
 
 export class AnalyticsQueue {
   private queue: AnalyticsEvent[] = [];

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,6 +13,11 @@ class InMemoryModelCache {
   private profileCache: Map<string, ModelProfile> = new Map();
   private lastFetched: number = 0;
   private readonly CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 1 week
+  private OPEN_ROUTER_API_KEY = '';
+
+  constructor(OPEN_ROUTER_API_KEY: string) {
+    this.OPEN_ROUTER_API_KEY = OPEN_ROUTER_API_KEY;
+  }
 
   async getModelProfiles(): Promise<ModelProfile[]> {
     const now = Date.now();
@@ -91,11 +96,11 @@ class InMemoryModelCache {
       logger.info('Fetching models from doer and generating profiles');
 
       // Use dynamic import to get env after it's been set by router
-      const { env } = await import('./config/env.js');
+      // const { env } = await import('./config/env.js');
 
       const response = await fetch('https://openrouter.ai/api/v1/models', {
         headers: {
-          Authorization: `Bearer ${env.OPEN_ROUTER_API_KEY}`,
+          Authorization: `Bearer ${this.OPEN_ROUTER_API_KEY}`,
           'Content-Type': 'application/json',
         },
       });
@@ -318,7 +323,8 @@ class InMemoryEmbeddingCache {
   }
 }
 
-export const modelCache = new InMemoryModelCache();
+// Create and export a singleton instance of embedding cache
+// But the model cacher requires API key and passing that API key on initialization via a singleton approach was problematic. So exporting the class.
 export const embeddingCache = new InMemoryEmbeddingCache();
 export { InMemoryModelCache, InMemoryEmbeddingCache };
 export type { ModelInfo };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,5 @@ export type {
 
 export { PromptType } from './types.js';
 
-// Export cache for advanced users who want to manage it directly
-export { modelCache } from './cache.js';
-
 // Default export for convenience
 export { AutoPromptRouter as default } from './router.js';


### PR DESCRIPTION
This pull request updates the initialization and usage of the model cache in the package to improve API key handling and make the cache instance more configurable. The most significant change is that the model cache now requires the OpenRouter API key to be passed explicitly to its constructor, removing reliance on environment variables and improving encapsulation. Additionally, the export of the cache instance has been removed from the public API, and analytics configuration has been updated to use a hardcoded endpoint.

**Model cache initialization and usage:**

* Refactored `InMemoryModelCache` to require the OpenRouter API key as a constructor parameter, storing it internally instead of relying on environment variables. [[1]](diffhunk://#diff-d027d3b9853e6bedddf63bd1d8fa67c69b4c1ff2b947685108f315e4e831cdbdR16-R20) [[2]](diffhunk://#diff-d027d3b9853e6bedddf63bd1d8fa67c69b4c1ff2b947685108f315e4e831cdbdL94-R103)
* Removed the singleton export of `modelCache` from `src/cache.ts`, and updated all usages in `src/router.ts` to use an instance variable initialized with the API key. [[1]](diffhunk://#diff-d027d3b9853e6bedddf63bd1d8fa67c69b4c1ff2b947685108f315e4e831cdbdL321-R327) [[2]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64L2-R2) [[3]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64R18) [[4]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64R28-L33) [[5]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64L46-R47) [[6]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64L97-R98) [[7]](diffhunk://#diff-bb8ff0dd16ff286e4086240831f70dd9233de8896f2f50219eeff29414affe64L185-R193)
* Removed the public export of `modelCache` from `src/index.ts`, so advanced users must now instantiate their own cache if needed.

**Analytics configuration:**

* Changed the analytics endpoint in `src/analytics/queue.ts` to a hardcoded URL, ensuring all users send data to the same endpoint for ML training.

**Version update:**

* Bumped the package version from `2.1.0` to `2.1.1` in `package.json` to reflect these changes.


Closing issues #3 , #12  

